### PR TITLE
Changed text/json to application/json

### DIFF
--- a/api.js
+++ b/api.js
@@ -81,10 +81,10 @@ http.createServer(function (req, res) {
             }
             dbo.close();
             if(result[0]){
-                res.writeHead(200, {'Content-Type': 'text/json'});
+                res.writeHead(200, {'Content-Type': 'application/json'});
                 res.write(JSON.stringify(result[0]));
             }else{
-                res.writeHead(400, {'Content-Type': 'text/json'});
+                res.writeHead(400, {'Content-Type': 'application/json'});
                 res.write(JSON.stringify({"error":"Invalid base or symbols"}))
             }
             res.end();


### PR DESCRIPTION
text/json isn't a content-type but application/json is. With this change, theJSON will be properly shown inside of browsers like Firefox that offer a cool json viewer. You can see an example of the viewer properly working for some JSON at this link: https://jsonplaceholder.typicode.com/todos/1